### PR TITLE
chore: remove custom properties from onDraw and move it on init

### DIFF
--- a/app/src/main/java/com/dicoding/storyapp/ui/customview/MyButtonSignIn.kt
+++ b/app/src/main/java/com/dicoding/storyapp/ui/customview/MyButtonSignIn.kt
@@ -37,16 +37,17 @@ class MyButtonSignIn : AppCompatButton {
 
   override fun onDraw(canvas: Canvas) {
     super.onDraw(canvas)
-    background = if (isEnabled) enabledBackground else disabledBackground
-
-    textSize = 15f
-    gravity = Gravity.CENTER
-    text = if (isEnabled) context.getString(sign_in) else context.getString(fill_all)
   }
 
   private fun init() {
+    textSize = 15f
+    gravity = Gravity.CENTER
+    text = if (isEnabled) context.getString(sign_in) else context.getString(fill_all)
+
     txtColor = ContextCompat.getColor(context, black)
     enabledBackground = ContextCompat.getDrawable(context, bg_button_regular) as Drawable
     disabledBackground = ContextCompat.getDrawable(context, bg_button_disable) as Drawable
+
+    background = if (isEnabled) enabledBackground else disabledBackground
   }
 }

--- a/app/src/main/java/com/dicoding/storyapp/ui/customview/MyEditTextEmail.kt
+++ b/app/src/main/java/com/dicoding/storyapp/ui/customview/MyEditTextEmail.kt
@@ -39,13 +39,14 @@ class MyEditTextEmail : TextInputEditText, View.OnTouchListener {
 
   override fun onDraw(canvas: Canvas) {
     super.onDraw(canvas)
-    setBackgroundResource(border_corner)
-    textSize = 15f
-    textAlignment = TEXT_ALIGNMENT_VIEW_START
   }
 
   private fun init() {
     clearButton = ContextCompat.getDrawable(context, ic_close) as Drawable // x button
+
+    setBackgroundResource(border_corner)
+    textSize = 15f
+    textAlignment = TEXT_ALIGNMENT_VIEW_START
 
     setOnTouchListener(this)
 

--- a/app/src/main/java/com/dicoding/storyapp/ui/customview/MyEditTextName.kt
+++ b/app/src/main/java/com/dicoding/storyapp/ui/customview/MyEditTextName.kt
@@ -36,13 +36,14 @@ class MyEditTextName : TextInputEditText, View.OnTouchListener {
 
   override fun onDraw(canvas: Canvas) {
     super.onDraw(canvas)
-    setBackgroundResource(border_corner)
-    textSize = 15f
-    textAlignment = TEXT_ALIGNMENT_VIEW_START
   }
 
   private fun init() {
     clearButton = ContextCompat.getDrawable(context, ic_close) as Drawable // x button
+
+    setBackgroundResource(border_corner)
+    textSize = 15f
+    textAlignment = TEXT_ALIGNMENT_VIEW_START
 
     setOnTouchListener(this)
 

--- a/app/src/main/java/com/dicoding/storyapp/ui/customview/MyEditTextPass.kt
+++ b/app/src/main/java/com/dicoding/storyapp/ui/customview/MyEditTextPass.kt
@@ -41,14 +41,15 @@ class MyEditTextPass : TextInputEditText, View.OnTouchListener {
 
   override fun onDraw(canvas: Canvas) {
     super.onDraw(canvas)
-    showEyeButton()
-    setBackgroundResource(border_corner)
-    textSize = 15f
-    textAlignment = TEXT_ALIGNMENT_VIEW_START
   }
 
   private fun init() {
     eyeIcon = ContextCompat.getDrawable(context, ic_eye_off) as Drawable // x button
+
+    showEyeButton()
+    setBackgroundResource(border_corner)
+    textSize = 15f
+    textAlignment = TEXT_ALIGNMENT_VIEW_START
 
     setOnTouchListener(this)
 


### PR DESCRIPTION
### Changes Made

- Migrate any custom properties from onDraw to init function on my custom view